### PR TITLE
优化系统配置工作台UI

### DIFF
--- a/front/src/views/SystemSettingsView.vue
+++ b/front/src/views/SystemSettingsView.vue
@@ -676,7 +676,7 @@ function handleError(error: unknown, title: string) {
           <RefreshCw :size="16" :class="{ spinning: refreshing }" />
           重新加载
         </button>
-        <a class="button ghost-link" href="/docs" target="_blank" rel="noreferrer">
+        <a class="button ghost-link" href="http://127.0.0.1:8000/docs" target="_blank" rel="noreferrer">
           API 文档
           <ArrowUpRight :size="16" />
         </a>


### PR DESCRIPTION
修改系统配置工作台页面中的API文档按钮的逻辑，当用户点击时跳转到http://127.0.0.1:8000/docs